### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   
 	<parent>
@@ -81,7 +81,7 @@
         <repository>
             <id>spring-snapshots</id>
             <name>Spring Snapshots</name>
-            <url>http://repo.spring.io/libs-snapshot-local</url>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -89,7 +89,7 @@
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
-            <url>http://repo.spring.io/libs-milestone-local</url>
+            <url>https://repo.spring.io/libs-milestone-local</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -97,7 +97,7 @@
         <repository>
             <id>spring-releases</id>
             <name>Spring Releases</name>
-            <url>http://repo.spring.io/libs-release-local</url>
+            <url>https://repo.spring.io/libs-release-local</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -108,7 +108,7 @@
         <pluginRepository>
             <id>spring-snapshots</id>
             <name>Spring Snapshots</name>
-            <url>http://repo.spring.io/libs-snapshot-local</url>
+            <url>https://repo.spring.io/libs-snapshot-local</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -116,7 +116,7 @@
         <pluginRepository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
-            <url>http://repo.spring.io/libs-milestone-local</url>
+            <url>https://repo.spring.io/libs-milestone-local</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).